### PR TITLE
README: added troubleshooting section to suggest what to do when the content directory is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ hugo server
 ```
 
 and view in http://localhost:1313
+
+### troubleshooting
+
+If you get the following error, create a directory named `content` and try again:
+
+> Error: Error building site: No source directory found, expecting to find it at [path]/content


### PR DESCRIPTION
I initially got an error when I tried to run hugo. I had to create a missing directory named content to solve this issue. I added a note to the README so that others can figure it out more quickly.